### PR TITLE
Do not allow breaking ABI by default

### DIFF
--- a/src/symbol_version/symbol_version.py
+++ b/src/symbol_version/symbol_version.py
@@ -1177,7 +1177,7 @@ def update(args):
             cur_map.releases.append(r)
 
     if removed:
-        if args.care:
+        if not args.allow_abi_break:
             msg = "ABI break detected: symbols would be removed"
             logger.error(msg)
             raise Exception(msg)
@@ -1420,8 +1420,8 @@ def get_arg_parser():
                                       " \'-i\', the symbols are read"
                                       " from the given file. Otherwise the"
                                       " symbols are read from stdin.")
-    parser_up.add_argument("-c", "--care",
-                           help="Do not continue if the ABI would be broken",
+    parser_up.add_argument("--allow-abi-break",
+                           help="Allow removing symbols, and to break ABI",
                            action='store_true')
     group = parser_up.add_mutually_exclusive_group(required=True)
     group.add_argument("-a", "--add", help="Adds the symbols to the map file.",

--- a/tests/data/test_update/broken_maps.yaml
+++ b/tests/data/test_update/broken_maps.yaml
@@ -19,6 +19,7 @@
     args:
       - "update"
       - "--symbols"
+      - "--allow-abi-break"
       - "--out"
       - "duplicated.out"
       - "duplicated.map"
@@ -80,6 +81,7 @@
     args:
       - "update"
       - "--symbols"
+      - "--allow-abi-break"
       - "--out"
       - "missing_visibility.out"
       - "missing_visibility.map"
@@ -173,6 +175,7 @@
     args:
       - "update"
       - "--symbols"
+      - "--allow-abi-break"
       - "--out"
       - "wildcard_warnings.out"
       - "wildcard_warnings.map"
@@ -204,6 +207,7 @@
     args:
       - "update"
       - "--symbols"
+      - "--allow-abi-break"
       - "--out"
       - "baseless.out"
       - "baseless.map"

--- a/tests/data/test_update/dont_break_api.stdout
+++ b/tests/data/test_update/dont_break_api.stdout
@@ -1,0 +1,3 @@
+Removed:
+    one_symbol
+

--- a/tests/data/test_update/overwrite.yaml
+++ b/tests/data/test_update/overwrite.yaml
@@ -4,6 +4,7 @@
     args:
       - "update"
       - "--symbols"
+      - "--allow-abi-break"
       - "--out"
       - "overwrite.map"
       - "overwrite.map"

--- a/tests/data/test_update/remove.in
+++ b/tests/data/test_update/remove.in
@@ -1,0 +1,1 @@
+one_symbol

--- a/tests/data/test_update/remove.yaml
+++ b/tests/data/test_update/remove.yaml
@@ -4,6 +4,7 @@
     args:
       - "update"
       - "--remove"
+      - "--allow-abi-break"
       - "--out"
       - "remove.map"
       - "remove.map"
@@ -22,6 +23,7 @@
     args:
       - "update"
       - "--remove"
+      - "--allow-abi-break"
       - "unexistent_symbol.map"
     stdin: "symbol.in"
   output:
@@ -35,6 +37,7 @@
     args:
       - "update"
       - "--remove"
+      - "--allow-abi-break"
       - "remove_with_wildcard.map"
     stdin: "symbol.in"
   output:
@@ -50,3 +53,16 @@
       - "Wildcard '*' found in global. Removed to avoid exporting unexpected \
         symbols."
     exceptions:
+-
+  input:
+    args:
+      - "update"
+      - "--remove"
+      - "base.map"
+    stdin: "remove.in"
+  output:
+    file:
+    stdout: "dont_break_api.stdout"
+    warnings:
+    exceptions:
+      - "ABI break detected: symbols would be removed"


### PR DESCRIPTION
Removed '--care' option and added '--allow-abi-break'. Symbols are not
removed and an Exception is raised if any symbol is removed and
'--allow-abi-break' is not used.