### PR TITLE
Improve logged information when --logfile is provided

### DIFF
--- a/src/symbol_version/symbol_version.py
+++ b/src/symbol_version/symbol_version.py
@@ -31,18 +31,10 @@ class Single_Logger(object):
         :param name: The name of the module (usually just __name__)
         :returns: An instance of logging.Logger
         """
+
         if Single_Logger.__instance is None:
             # Get logger
             logger = logging.getLogger(name)
-
-            if filename:
-                file_handler = logging.FileHandler(filename)
-                file_format = "".join(["[%(levelname)s] (%(asctime)s) in",
-                                       " %(filename)s, line %(lineno)d:",
-                                       " %(message)s"])
-                file_formatter = logging.Formatter(file_format)
-                file_handler.setFormatter(file_formatter)
-                logger.addHandler(file_handler)
 
             # Setup a handler to print warnings and above to stderr
             console_handler = logging.StreamHandler()
@@ -54,6 +46,17 @@ class Single_Logger(object):
             logger.addHandler(console_handler)
 
             Single_Logger.__instance = logger
+
+        if filename:
+            # If a new logfile is added, a handler is added
+            file_handler = logging.FileHandler(filename)
+            file_format = "".join(["[%(levelname)s] (%(asctime)s) in",
+                                   " %(filename)s, line %(lineno)d:",
+                                   " %(message)s"])
+            file_formatter = logging.Formatter(file_format)
+            file_handler.setFormatter(file_formatter)
+            Single_Logger.__instance.addHandler(file_handler)
+
         return Single_Logger.__instance
 
 

--- a/src/symbol_version/symbol_version.py
+++ b/src/symbol_version/symbol_version.py
@@ -37,6 +37,11 @@ class Single_Logger(object):
 
             if filename:
                 file_handler = logging.FileHandler(filename)
+                file_format = "".join(["[%(levelname)s] (%(asctime)s) in",
+                                       " %(filename)s, line %(lineno)d:",
+                                       " %(message)s"])
+                file_formatter = logging.Formatter(file_format)
+                file_handler.setFormatter(file_formatter)
                 logger.addHandler(file_handler)
 
             # Setup a handler to print warnings and above to stderr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,5 +146,24 @@ def run_tc(tc, datadir, capsys, caplog):
             for expected in tc_out["warnings"]:
                 assert expected in caplog.text
 
+        # If a log file was supposed to exist, check the content
+        if args.logfile:
+            if os.path.isfile(args.logfile):
+                with open(args.logfile, "r") as log:
+                    logged = log.read()
+                    if tc_out["warnings"]:
+                        for expected in tc_out["warnings"]:
+                            assert expected in logged
+                    if tc_out["exceptions"]:
+                        for expected in tc_out["exceptions"]:
+                            assert expected in logged
+            else:
+                if tc_out["warnings"] or tc_out["exceptions"]:
+                    with capsys.disabled():
+                        print(tc)
+                        print("Expected to have a logfile:\n" + args.logfile)
+                    # Fail
+                    assert 0
+
         # Clear the captured log and output so far
         caplog.clear()

--- a/tests/data/test_update/logfile.yaml
+++ b/tests/data/test_update/logfile.yaml
@@ -1,0 +1,34 @@
+# Testing with logfile option
+-
+  input:
+    args:
+      - "update"
+      - "--symbols"
+      - "--logfile"
+      - "wildcard_warnings.log"
+      - "--out"
+      - "wildcard_warnings_with_log.out"
+      - "wildcard_warnings.map"
+    stdin: "symbol.in"
+  output:
+    file:
+    stdout: "wildcard_warnings_no_abi_break.stdout"
+    warnings:
+      - "NOTBASE_1_1_0 should not contain the local wildcard because it is \
+        not the base version (it refers to version BASE_1_0_0 as its \
+        predecessor)"
+      - "GLOBAL_WILDCARD_1_2_0 contains the '*' wildcard in global scope. \
+        It is probably exporting symbols it should not."
+      - "SCOPES_1_3_0contains unknown scope named scope (different from  \
+        'global' and 'local')"
+      - "The '*' wildcard was found in more than one place:"
+      - "    NOTBASE_1_1_0: in 'local'"
+      - "    BASE_1_0_0: in 'local'"
+      - "    GLOBAL_WILDCARD_1_2_0: in 'global'"
+      - "    OTHER_BASE_1_0_0: in 'local'"
+      - "More than one release seems the base version (contains the local \
+        wildcard and does not have a predecessor version):"
+      - "   BASE_1_0_0"
+      - "   OTHER_BASE_1_0_0"
+    exceptions:
+      - "ABI break detected: symbols would be removed"

--- a/tests/data/test_update/wildcard_warnings_no_abi_break.stdout
+++ b/tests/data/test_update/wildcard_warnings_no_abi_break.stdout
@@ -1,0 +1,8 @@
+Added:
+    symbol
+
+Removed:
+    *
+    one_symbol
+    three_symbol
+


### PR DESCRIPTION
This adds a better formatter for the logged information when --logfile is provided.
It also changes the behaviour of the Single_Logger: a new handler is added every time the Single_Logger factory is called passing a logfile. This may lead to side-effects like doubling the log entries if the same file is passed more than once. Probably it is not the case since the filename is provided only when the new or update command are called.

Fixes #22 