### PR TITLE
Add tests using symbol_version as library

### DIFF
--- a/tests/data/test_as_lib/base.map
+++ b/tests/data/test_as_lib/base.map
@@ -1,0 +1,9 @@
+# Simple base map
+
+BASE_1_0_0
+{
+    global:
+        one_symbol;
+    local:
+        *;
+} ;

--- a/tests/data/test_as_lib/empty_map.stdout
+++ b/tests/data/test_as_lib/empty_map.stdout
@@ -1,0 +1,8 @@
+BASE_1_0_0
+{
+    global:
+        one_symbol;
+    local:
+        *;
+} ;
+

--- a/tests/data/test_as_lib/without_prefix.map
+++ b/tests/data/test_as_lib/without_prefix.map
@@ -1,0 +1,10 @@
+# Map without prefix
+
+1_0_0
+{
+    global:
+        one_symbol;
+    local:
+        *;
+} ;
+

--- a/tests/data/test_as_lib/without_similar_prefix.map
+++ b/tests/data/test_as_lib/without_similar_prefix.map
@@ -1,0 +1,18 @@
+# Map without similar prefix
+
+BASE_1_0_0
+{
+    global:
+        one_symbol;
+    local:
+        *;
+} ;
+
+OTHER_BASE_1_0_0
+{
+    global:
+        one_symbol;
+    local:
+        *;
+} ;
+

--- a/tests/data/test_as_lib/without_version.map
+++ b/tests/data/test_as_lib/without_version.map
@@ -1,0 +1,9 @@
+# Map without version information
+
+BASE
+{
+    global:
+        one_symbol;
+    local:
+        *;
+} ;

--- a/tests/test_as_lib.py
+++ b/tests/test_as_lib.py
@@ -1,0 +1,110 @@
+# /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests using as library"""
+
+import pytest
+from conftest import cd
+
+from symbol_version import symbol_version
+
+
+def test_unitialized_all_global_symbols():
+    m = symbol_version.Map()
+
+    expected = "Map not checked, run check()"
+    symbols = None
+
+    with pytest.raises(Exception) as e:
+        symbols = m.all_global_symbols()
+        assert expected in str(e.value)
+
+    assert not symbols
+
+
+def test_unitialized_guess_latest_release():
+    m = symbol_version.Map()
+
+    expected = "Map not checked, run check()"
+    symbols = None
+
+    with pytest.raises(Exception) as e:
+        symbols = m.guess_latest_release()
+        assert expected in str(e.value)
+
+    assert not symbols
+
+
+def test_unitialized_sort_releases_nice():
+    m = symbol_version.Map()
+
+    expected = "Map not checked, run check()"
+    symbols = None
+
+    with pytest.raises(Exception) as e:
+        symbols = m.sort_releases_nice(None)
+        assert expected in str(e.value)
+
+    assert not symbols
+
+
+def test_empty_map(datadir):
+    m = symbol_version.Map()
+
+    expected = "Empty map"
+
+    with pytest.raises(Exception) as e:
+        m.check()
+        assert expected in str(e.value)
+
+    with cd(datadir):
+        m.read("base.map")
+
+        m.check()
+
+        out = str(m)
+
+        with open("empty_map.stdout") as tcout:
+            assert out == tcout.read()
+
+
+def test_guess_name_without_version(datadir):
+
+    m = symbol_version.Map()
+
+    expected = "".join(["Insufficient information to guess the new release",
+                        " name. Releases found do not have version",
+                        " information or a valid library name. Please",
+                        " provide the complete name of the release."])
+
+    with cd(datadir):
+        with pytest.raises(Exception) as e:
+            m.read("without_version.map")
+            m.guess_name()
+
+            assert expected in str(e.value)
+
+
+def test_guess_name_without_prefix(datadir):
+
+    m = symbol_version.Map()
+    expected = "".join(["Insufficient information to guess the new release",
+                        " name. Releases found do not have version",
+                        " information or a valid library name. Please",
+                        " provide the complete name of the release."])
+
+    with cd(datadir):
+        with pytest.raises(Exception) as e:
+            m.read("without_prefix.map")
+            m.guess_name()
+
+            assert expected in str(e.value)
+
+
+def test_guess_name_without_similar_prefix(datadir):
+
+    m = symbol_version.Map()
+
+    with cd(datadir):
+        m.read("without_similar_prefix.map")
+        m.guess_name()


### PR DESCRIPTION
The added tests use the module as a library instead as a command line
application.

The code was reorganized, adding huge comments separators.