### PR TITLE
Guess

### DIFF
--- a/src/symbol_version/symbol_version.py
+++ b/src/symbol_version/symbol_version.py
@@ -1040,7 +1040,20 @@ def get_info_from_args(args):
     if args.release:
         # Parse the release name string to get info
         release_info = get_info_from_release_string(args.release)
-        # TODO insert name or version when provided
+
+        if args.name:
+            m = re.search(r'\w+', args.name)
+            if m:
+                release_info[1] = m.group()
+        if args.version:
+            version = get_version_from_string(args.version)
+            new_suffix = "".join(("_" + str(i) for i in version))
+            release_info[2] = new_suffix
+            release_info[3] = version
+
+        if release_info:
+            if release_info[1] and release_info[2]:
+                release_info[0] = release_info[1] + release_info[2]
     elif args.name and args.version:
         # Parse the given version string to get the version information
         version = get_version_from_string(args.version)
@@ -1104,8 +1117,6 @@ def update(args):
 
     # Get the release information provided in the arguments
     release_info = get_info_from_args(args)
-    logger.debug("Release info in args:")
-    logger.debug(str(release_info))
 
     # Read the current map file
     cur_map = Map(filename=args.file, logger=logger)
@@ -1311,6 +1322,15 @@ def new(args):
 
     # Get the release information provided in the arguments
     release_info = get_info_from_args(args)
+
+    # In the new command, there is no way to guess the name, since there are
+    # not previous information. So the exception have to be raised early to
+    # avoid collecting the new symbols and then find out we do not have a name
+    if not release_info:
+        msg = "Please provide the release name."
+        logger.error(msg)
+        raise Exception(msg)
+
     logger.debug("Release info in args:")
     logger.debug(str(release_info))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,8 +102,8 @@ def run_tc(tc, datadir, capsys, caplog):
         if tc_out["exceptions"]:
             with pytest.raises(Exception) as e:
                 args.func(args)
-                for expected in tc_out["exceptions"]:
-                    assert expected in str(e.value)
+            for expected in tc_out["exceptions"]:
+                assert expected in str(e.value)
         else:
             args.func(args)
 

--- a/tests/data/test_new/guess_names.yaml
+++ b/tests/data/test_new/guess_names.yaml
@@ -38,8 +38,10 @@
   input:
     args:
       - "new"
-      - "-r release_1.1.0"
-      - "-name other"
+      - "-r"
+      - "release_1.1.0"
+      - "--name"
+      - "other"
     stdin: "symbol.in"
   output:
     file:
@@ -60,6 +62,4 @@
         the library identifier and the version information). \
         Suggested: something like LIBNAME_1_2_3"
     exceptions:
-      - "Insufficient information to guess the new release name. Releases \
-        found do not have version information or a valid library name. \
-        Please provide the complete name of the release."
+      - "Please provide the release name."

--- a/tests/data/test_new/guess_names.yaml
+++ b/tests/data/test_new/guess_names.yaml
@@ -60,4 +60,6 @@
         the library identifier and the version information). \
         Suggested: something like LIBNAME_1_2_3"
     exceptions:
-      - "Could not retrieve release information."
+      - "Insufficient information to guess the new release name. Releases \
+        found do not have version information or a valid library name. \
+        Please provide the complete name of the release."

--- a/tests/data/test_new/options.yaml
+++ b/tests/data/test_new/options.yaml
@@ -81,7 +81,9 @@
         the library identifier and the version information). \
         Suggested: something like LIBNAME_1_2_3"
     exceptions:
-      - "Could not retrieve release information."
+      - "Insufficient information to guess the new release name. Releases \
+        found do not have version information or a valid library name. \
+        Please provide the complete name of the release."
 -
   input:
     args:

--- a/tests/data/test_new/options.yaml
+++ b/tests/data/test_new/options.yaml
@@ -81,9 +81,7 @@
         the library identifier and the version information). \
         Suggested: something like LIBNAME_1_2_3"
     exceptions:
-      - "Insufficient information to guess the new release name. Releases \
-        found do not have version information or a valid library name. \
-        Please provide the complete name of the release."
+      - "Please provide the release name."
 -
   input:
     args:

--- a/tests/data/test_new/release_and_name.stdout
+++ b/tests/data/test_new/release_and_name.stdout
@@ -1,6 +1,6 @@
 # This map file was created with symbol_version.py
 
-RELEASE_1_1_0
+OTHER_1_1_0
 {
     global:
         symbol;

--- a/tests/data/test_new/release_and_version.stdout
+++ b/tests/data/test_new/release_and_version.stdout
@@ -1,6 +1,6 @@
 # This map file was created with symbol_version.py
 
-RELEASE_1_1_0
+RELEASE_2_0_0
 {
     global:
         symbol;

--- a/tests/data/test_overwrite_protected/overwrite_protected.yaml
+++ b/tests/data/test_overwrite_protected/overwrite_protected.yaml
@@ -19,5 +19,5 @@
       - "Could no copy 'overwrite_protected.in' to \
         'overwrite_protected.in.old'. Aborting."
     exceptions:
-      - "Permission denied: 'overwrite_protected.out'"
+      - "Permission denied: 'overwrite_protected.in.old'"
 

--- a/tests/test_as_lib.py
+++ b/tests/test_as_lib.py
@@ -80,7 +80,7 @@ def test_guess_name_without_version(datadir):
     with cd(datadir):
         with pytest.raises(Exception) as e:
             m.read("without_version.map")
-            m.guess_name()
+            m.guess_name(None, guess=True)
 
             assert expected in str(e.value)
 
@@ -96,7 +96,7 @@ def test_guess_name_without_prefix(datadir):
     with cd(datadir):
         with pytest.raises(Exception) as e:
             m.read("without_prefix.map")
-            m.guess_name()
+            m.guess_name(None, guess=True)
 
             assert expected in str(e.value)
 
@@ -107,4 +107,4 @@ def test_guess_name_without_similar_prefix(datadir):
 
     with cd(datadir):
         m.read("without_similar_prefix.map")
-        m.guess_name()
+        m.guess_name(None, guess=True)


### PR DESCRIPTION
This adds --no-guess option to disable automatic release name guessing and changes the release naming behaviour when --release is provided together with --name or --version.

When the --release and --name are provided together, the name provided
in --name have priority over the prefix provided in --release.
This mean if 'OLD_1_0_0' is provided in --release and 'LIBX' is provided
in --name, the used release name will be 'LIBX_1_0_0'.

In the same way, if --release and --version are provided, the version
provided in --version have priority over the version suffix provided in
--release.

Fixes #21 
Fixes #23